### PR TITLE
build a dummy API to ease the development of the frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ raw_data/
 *.ipynb_*
 
 **/.vscode/*
+*.joblib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8.13-buster
+
+COPY ./api /api
+COPY ./ephesus /ephesus
+COPY ./requirements.txt /requirements.txt
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+CMD uvicorn api.fast:app --host 0.0.0.0 --port $PORT

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,28 @@ pypi_test:
 
 pypi:
 	@twine upload dist/* -u $(PYPI_USERNAME)
+
+
+##### Prediction API - - - - - - - - - - - - - - - - - - - - - - - - -
+
+run_api:
+	uvicorn api.fast:app --reload  # load web server with code autoreload
+
+##### Docker - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# project id
+PROJECT_ID=crypto-galaxy-351308
+# docker image name
+DOCKER_IMAGE_NAME=ephesus-api
+
+docker_build:
+	docker build --tag eu.gcr.io/${PROJECT_ID}/${DOCKER_IMAGE_NAME} .
+
+docker_run:
+	docker run -e PORT=8000 -p 8000:8000 eu.gcr.io/${PROJECT_ID}/${DOCKER_IMAGE_NAME}
+
+docker_push:
+	docker push eu.gcr.io/${PROJECT_ID}/${DOCKER_IMAGE_NAME}
+
+docker_deploy:
+	gcloud run deploy --image eu.gcr.io/${PROJECT_ID}/${DOCKER_IMAGE_NAME} --platform managed --region europe-west1

--- a/api/fast.py
+++ b/api/fast.py
@@ -1,0 +1,61 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+import joblib
+
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allows all origins
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
+
+@app.get("/")
+def index():
+    return {"greeting": "Hello world"}
+
+@app.get("/test")
+def test(sentence):
+    '''
+    return a dummy sentence with entities
+    this is to enable development of the front end
+    '''
+    # create dummy sentence to be returned (ignore incoming sentence)
+    dummy_sentence = (
+        "Un ",
+        ("grand pansement", "traitement", "#8ef"),
+        " à ",
+        ("domicile", "lieux", "#faa"),
+        (" à partir du "),
+        ("3 juin", "date", "#afa"),
+        " , ",
+        ("tous les deux jours", "fréquence", "#fea"),
+        " ",
+        ("pendant 3 semaines", "durée", "#8ef"),
+        " à ",
+        ("18h", "heure", "#afa"),
+        "."
+    )
+
+    # load the pre-trained model
+    #try:
+    #    model = joblib.load("model.joblib")
+    #except FileNotFoundError:
+    #    return {"error" : "oops"}
+
+    # compute prediction
+    #y_pred = model.predict(X_pred)
+
+    # return predicted
+    return {"entities" : dummy_sentence}
+
+@app.get("/predict")
+def predict():
+    return {"greeting": "not coded yet"}
+
+if __name__ == "__main__":
+    print(test("hello"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ gcsfs
 google-cloud-storage
 mlflow
 s3fs
+fastapi
+uvicorn
 
 # utilities
 six>=1.14


### PR DESCRIPTION
build a dummy API to ease the development of the frontend.
The dummy API will always return the same sentence (it's just a dummy).
Use the Makefile to build the docker image and deploy it on google cloud.
Once the API is live, it can be used to test the frontend (the endpoint for that is "/test").
The API is deployed on https://ephesus-api-3d2vvkkptq-ew.a.run.app/